### PR TITLE
Add basic legal pages for TikTok dev requirements

### DIFF
--- a/database/menuSeed.ts
+++ b/database/menuSeed.ts
@@ -57,6 +57,20 @@ export const seedMainMenu: IResponseMenu = {
                             "label": "Opiniones",
                             "url": "#testimonials"
                         },
+                        {
+                            "meta": {
+                                "id": 328649
+                            },
+                            "label": "Términos de Servicio",
+                            "url": "/terms-of-service"
+                        },
+                        {
+                            "meta": {
+                                "id": 328650
+                            },
+                            "label": "Política de Privacidad",
+                            "url": "/privacy-policy"
+                        },
                         // {
                         //     "meta": {
                         //         "id": 328646

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head'
+
+export default function PrivacyPolicy() {
+  return (
+    <section className="py-5">
+      <Head>
+        <title>Wankar - Política de Privacidad</title>
+        <meta name="description" content="Política de privacidad de Wankar" />
+      </Head>
+      <div className="container">
+        <h1>Política de Privacidad</h1>
+        <p>En Wankar respetamos tu privacidad. La información personal que recopilamos se utiliza únicamente para proveer y mejorar nuestros servicios. No compartimos tus datos con terceros salvo que sea necesario para operar nuestra plataforma o cumplir con obligaciones legales.</p>
+        <p>Si te registras utilizando TikTok u otros proveedores, solo almacenamos los datos mínimos necesarios para autenticarte y brindarte acceso. Puedes solicitar la eliminación de tus datos escribiendo a <a href="mailto:privacidad@wankar.com">privacidad@wankar.com</a>.</p>
+        <p>Podemos actualizar esta política ocasionalmente. Te notificaremos cualquier cambio publicando la nueva versión en este sitio.</p>
+      </div>
+    </section>
+  )
+}

--- a/pages/terms-of-service.tsx
+++ b/pages/terms-of-service.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head'
+
+export default function TermsOfService() {
+  return (
+    <section className="py-5">
+      <Head>
+        <title>Wankar - Términos de Servicio</title>
+        <meta name="description" content="Términos de servicio de Wankar" />
+      </Head>
+      <div className="container">
+        <h1>Términos de Servicio</h1>
+        <p>Bienvenido a Wankar. Al utilizar nuestros servicios aceptas los siguientes términos y condiciones. Nuestro sitio ofrece soluciones de software y facturación electrónica. Todas las funcionalidades, incluyendo integraciones con terceros como TikTok, se proporcionan conforme a estas condiciones.</p>
+        <p>Los usuarios deben respetar nuestras políticas de uso y cumplir con la normativa aplicable. Nos reservamos el derecho a actualizar estos términos cuando sea necesario. Si continúas utilizando el sitio tras publicarse los cambios, aceptas los términos actualizados.</p>
+        <p>Si tienes preguntas sobre estos términos, contáctanos en <a href="mailto:info@wankar.com">info@wankar.com</a>.</p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple Terms of Service page
- add a Privacy Policy page
- link legal pages from the seeded menu

## Testing
- `yarn lint` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ee2a242dc83309fc4271c7f9be148